### PR TITLE
Fix ir_agent false positive in BPFDoor port check

### DIFF
--- a/BPFDoor/rapid7_detect_bpfdoor.sh
+++ b/BPFDoor/rapid7_detect_bpfdoor.sh
@@ -252,6 +252,16 @@ check_maps_hex() {
   done
 }
 
+# ------ Helper: Check if it is Rapid 7 agent ----------------------------
+is_rapid7_ir_agent() {
+  local pid="$1"
+  local pidprog="$2"
+
+  [[ "$pidprog" == *"ir_agent"* ]] && return 0
+
+  return 1
+}
+
 # ---- Check 1: Mutex / lock files ------------------------------------------
 check_mutex_files() {
   log "INFO" "[1/12] Checking /var/run for suspicious zero-byte mutex/lock files"
@@ -468,6 +478,13 @@ check_suspicious_ports() {
     [[ "$line" =~ ^tcp ]] || continue
     local laddr raddr state pidprog
     read -r _ _ laddr raddr state pidprog <<<"$line"
+
+    local pid="${pidprog%%/*}"
+    [[ "$pid" =~ ^[0-9]+$ ]] || pid=""
+    if is_rapid7_ir_agent "$pid" "$pidprog"; then
+      continue
+    fi
+
     local lport="${laddr##*:}"
     local rport="${raddr##*:}"
 


### PR DESCRIPTION
This change prevents a false positive in Check 6 (historical BPFDoor ports)
where the Rapid7 Insight Agent (ir_agent) listens on loopback using ephemeral
ports within the flagged range.

The fix is process-based (port-agnostic) and skips connections owned by ir_agent,
avoiding alert noise while preserving BPFDoor detection coverage.