### PR TITLE
Require root before creating or truncating BPFDoor report log file

### DIFF
--- a/BPFDoor/rapid7_detect_bpfdoor.sh
+++ b/BPFDoor/rapid7_detect_bpfdoor.sh
@@ -819,8 +819,8 @@ check_persistence() {
 
 # ---- Main ------------------------------------------------------------------
 main() {
-  : > "$LOGFILE"
   require_root
+  : > "$LOGFILE"
   banner
 
   echo -e "\n${CYAN}[*] Running Ultimate BPFDoor triage…${NC}"


### PR DESCRIPTION
This PR fixes an execution-order issue in `main()` where the script attempts to create/truncate the report logfile before enforcing the root privilege requirement.

## Problem

a non-root user can trigger an unintended write attempt in a non-writable working directory which produces a permission denied error before the script then exits on the root check anyway

Current flow:

```bash
main() {
  : > "$LOGFILE"
  require_root
  banner
```
## Fix

Move `require_root` ahead of logfile creation/truncation so privilege is validated before any local persistent action is attempted.

Updated flow:

```bash
main() {
  require_root
  : > "$LOGFILE"
  banner
```