### PR TITLE
Fix Stage 4 self-exclusion to use is_self() consistently

### DIFF
--- a/BPFDoor/rapid7_detect_bpfdoor.sh
+++ b/BPFDoor/rapid7_detect_bpfdoor.sh
@@ -388,14 +388,12 @@ check_raw_and_packet_sockets() {
 
   for pid in $unique_pids; do
     # Self-exclusion
-    [ "$pid" -eq "$SELF_PID" ] 2>/dev/null && continue
+    is_self "$pid" && continue
     [ -d "/proc/$pid" ] || continue
 
     local exe_path=$(readlink -f "/proc/$pid/exe" 2>/dev/null || echo "unknown")
-    
-    # Skip if it's this detection script
-    [ "$exe_path" == "$SELF_EXE" ] && continue
- #exclude legitimate networking tools
+
+    # exclude legitimate networking tools
     if [[ "$exe_path" == *"/NetworkManager"* ]] || [[ "$exe_path" == *"/dhclient"* ]] || [[ "$exe_path" == *"/systemd-networkd"* ]]; then
       continue
     fi


### PR DESCRIPTION
## Summary

Stage 4 (`check_raw_and_packet_sockets`) currently performs self-exclusion using
`SELF_PID` and `SELF_EXE`, but those variables are not declared anywhere in the
script.

This PR replaces those checks with the existing `is_self()` helper, which is
already the script's standard mechanism for excluding the current script process
and its parent process.

## Why this change

The current Stage 4 implementation is internally inconsistent with the rest of
the script:

- `is_self()` is the established helper used by the other PID-oriented checks.
- Stage 4 instead references undeclared `SELF_PID` / `SELF_EXE`.
- As a result, Stage 4's intended self-exclusion is not implemented as intended.

## Scope

Changed:
- Stage 4 self-exclusion now uses `is_self "$pid"`.

## Rationale for minimalism

Based on review, a self-check is not strictly required for Stage 4 to detect the
intended raw/packet socket activity, because the script itself does not normally
open those sockets. However, since the code clearly intends to have a self-
exclusion path, the smallest defensible fix is to use the already-existing
helper rather than leaving broken undeclared-variable checks in place.