### PR TITLE
Silence transient /proc race errors in Stage 5 environment triage

### DIFF
--- a/BPFDoor/rapid7_detect_bpfdoor.sh
+++ b/BPFDoor/rapid7_detect_bpfdoor.sh
@@ -427,7 +427,7 @@ check_env_vars() {
     local pid="${pid_dir##*/}"
     is_self "$pid" && continue
     
-    local env="$(tr '\0' '\n' < "$pid_dir/environ" 2>/dev/null || true)"
+    local env="$(tr '\0' '\n' 2>/dev/null < "$pid_dir/environ" || true)"
     [ -z "$env" ] && continue
 
     if echo "$env" | grep -qx "HOME=/tmp" \


### PR DESCRIPTION
## Summary

Stage 5 (`check_env_vars`) can print noisy `No such process` messages while
iterating `/proc/*/environ` on busy systems.

This is caused by a normal `/proc` race: a process may exit after the script
tests readability but before Bash opens the file for input redirection.

## Problem

The current code uses:

```bash
local env="$(tr '\0' '\n' < "$pid_dir/environ" 2>/dev/null || true)"
```

With this ordering, the shell attempts the input redirection before stderr is
redirected, so Bash may still emit an open failure message even though the code
already tolerates the read failure logically.

## Fix

Reorder the redirection to:
```bash
local env="$(tr '\0' '\n' 2>/dev/null < "$pid_dir/environ" || true)""
```

This preserves stage behavior, but suppresses Bash errors when the process disappears between enumeration and open.